### PR TITLE
Revert "Update python Docker tag to v3.12 (#102)"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.11-slim
 LABEL maintainer="Luke Tainton <luke@tainton.uk>"
 LABEL org.opencontainers.image.source="https://github.com/luketainton/roboluke-tasks"
 USER root


### PR DESCRIPTION
This reverts commit 1ce741dcdad617c1173a78e35fb1d5f5e900cc73.

https://bugs.launchpad.net/brz/+bug/2026813

Upgrade to Python 3.12 removes `imp`. Dependent packages are still reliant on this package.